### PR TITLE
Added reference to os for getting the correct EOL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var dns = require('dns'),
-	net = require('net');
+    net = require('net'),
+    os = require('os');
 
 module.exports = function (email, callback, timeout) {
 	timeout = timeout || 5000;
@@ -28,7 +29,7 @@ module.exports = function (email, callback, timeout) {
 			conn.on('prompt', function () {
 				if(i < 3){
 					conn.write(commands[i]);
-					conn.write('\n');
+					conn.write(os.EOL);
 					i++;
 				} else {
 					callback(err, true);


### PR DESCRIPTION
I noticed that on Windows 7 I could run into problems by using '\n' as EOL sequence. Therefore, I added the reference to the 'os' node package to always get the right EOL sequence.
