### PR TITLE
Added conn.destroy to fix ECONNRESET bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,12 +34,14 @@ module.exports = function (email, callback, timeout) {
 				} else {
 					callback(err, true);
 					conn.removeAllListeners();
+					conn.destroy(); //destroy socket manually
 				}
 			});
 			conn.on('undetermined', function () {
 				//in case of an unrecognisable response tell the callback we're not sure
 				callback(err, false, true);
 				conn.removeAllListeners();
+				conn.destroy(); //destroy socket manually
 			});
 			conn.on('timeout', function () {
 				conn.emit('undetermined');


### PR DESCRIPTION
Found a bug where ECONNRESET would be thrown after the socket on port 25 abruptely closes. This consistenly resulted in my express server crashing. Adding conn.destroy() after conn.removeAllListeners() will ensure the port is closed then and there, preventing an error to be thrown when it eventually closes unexpectedly. Minor testing seems to indicate that .destroy() is not needed on the 'error' and 'false' events, but I could be mistaken. Further testing may be required to ensure the ECONNRESET bug is truly fixed.

Cheers,
Ben.
