### PR TITLE
fixing the issue that returns a help page if the IP is blocked: http://p...

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,15 +47,15 @@ module.exports = function (email, callback, timeout, from_email) {
 			conn.on('timeout', function () {
 				conn.emit('undetermined');
 			});
-			conn.on('data', function(data) {
-				if(data.indexOf("220") != -1 || data.indexOf("250") != -1) {
-					conn.emit('prompt');
-				} else if(data.indexOf("550") != -1) {
-					conn.emit('false');
-				} else {
-					conn.emit('undetermined');
-				}
-			});
+                        conn.on('data', function(data) {
+                                if(data.indexOf("220") == 0 || data.indexOf("250") == 0 || data.indexOf("\n220") != -1 || data.indexOf("\n250") != -1) {
+                                        conn.emit('prompt');
+                                } else if(data.indexOf("\n550") != -1 || data.indexOf("550") == 0) {
+                                        conn.emit('false');
+                                } else {
+                                        conn.emit('undetermined');
+                                }
+                        });
 		});
 	});
 };


### PR DESCRIPTION
fixing the issue that returns a help page if the IP is blocked: http://postmaster.yahoo.com/550-bl23.html. there is a \"550\" in the name of the page which makes us think that the address doesn't exist where in fact, yahoo has blocked the IP. 

Yahoo returns something like this when the IP is blocked:

220 mta1035.mail.ne1.yahoo.com ESMTP ready

250 mta1035.mail.ne1.yahoo.com

553 5.7.1 [BL21] Connections will not be accepted from a.b.c.d, because the ip is in Spamhaus's list; see http://postmaster.yahoo.com/550-bl23.html

In this case, we should emit undetermined and not false (without this patch, we would return false because of the 550 being in http://postmaster.yahoo.com/550-bl23.html).
